### PR TITLE
Fix the converting constructor of any_invocable.

### DIFF
--- a/test/invocable_ut.cpp
+++ b/test/invocable_ut.cpp
@@ -220,5 +220,10 @@ TEST_CASE("Swap and comparisons", "[any_invocable]") {
   }
 }
 
+TEST_CASE("Static checks", "[any_invocable]") {
+  STATIC_REQUIRE(!std::is_copy_constructible_v<ofats::any_invocable<void()>>);
+  STATIC_REQUIRE(std::is_move_constructible_v<ofats::any_invocable<void()>>);
+}
+
 // TODO(ofats): small vs. large tests, number of move,ctor,dtor test,
 // ill/well-formed checks...


### PR DESCRIPTION
Using std::conjunction instead of logic "and" for converting constructor constraints fixes the problem: is_constructible now won't be instantiated if remove_cvref<F> is the same type as any_invocable.